### PR TITLE
Flatten `storage access status` algorithm steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -122,12 +122,16 @@ A <dfn>storage access status</dfn> is one of "<dfn for="storage access status">n
         1. If the user agent's cookie store would attach cookies with the `SameSite=Strict` attribute to |request|, return null. [[!COOKIES]]
         1. Let |allowed| be a [=boolean=], initially set to the result of [=determining whether the user agent's cookie store allows unpartitioned cookies to be accessed=] given |request|'s [=request/url=], |request|'s [=request/client=], and |request|'s [=request/eligible for storage-access=].
         1. If |allowed| is true, return "<code>[=storage access status/active=]</code>".
-        1. Let |allowedByPolicy| the result of running [$Should request be allowed to use feature?$] given "<code>storage-access</code>" and |request|.
-        1. If |allowedByPolicy| is true and |request|'s [=request/eligible for storage-access=] is false, then:
-            1. Set |allowed| to the result of [=determining whether the user agent's cookie store allows unpartitioned cookies to be accessed=] given |request|'s [=request/url=], |request|'s [=request/client=], and `true`.
-            1. If |allowed| is true, return "<code>[=storage access status/inactive=]</code>".
+        1. If |request|'s [=request/eligible for storage-access=] is true, return "<code>[=storage access status/none=]</code>".
 
-                Note: |allowed| will be true in the above step if the [=permission store entry=] obtained by [=getting a permission store entry=] given a {{PermissionDescriptor}} with {{PermissionDescriptor/name}} initialized to "`storage-access`" and a [=permission key=] of <code>(the site [=obtain a site|obtained=] from [=request=]'s [=request/client=]'s [=environment/top-level origin=], the site [=obtain a site|obtained=] from [=request=]'s [=request/url=]'s [=url/origin=])</code> has a [=permission store entry/state=] of "`granted`". Otherwise, |allowed| will remain false.
+            Note: the "`storage-access`" [=policy-controlled feature=] was checked before setting |request|'s [=request/eligible for storage-access=] to true.
+
+        1. Let |featureIsAllowed| the result of running [$Should request be allowed to use feature?$] given "<code>storage-access</code>" and |request|.
+        1. If |featureIsAllowed| is false, return "<code>[=storage access status/none=]</code>".
+        1. Set |allowed| to the result of [=determining whether the user agent's cookie store allows unpartitioned cookies to be accessed=] given |request|'s [=request/url=], |request|'s [=request/client=], and `true`.
+        1. If |allowed| is true, return "<code>[=storage access status/inactive=]</code>".
+
+            Note: |allowed| will be true in the above step if the [=permission store entry=] obtained by [=getting a permission store entry=] given a {{PermissionDescriptor}} with {{PermissionDescriptor/name}} initialized to "`storage-access`" and a [=permission key=] of <code>(the site [=obtain a site|obtained=] from [=request=]'s [=request/client=]'s [=environment/top-level origin=], the site [=obtain a site|obtained=] from [=request=]'s [=request/url=]'s [=url/origin=])</code> has a [=permission store entry/state=] of "`granted`". Otherwise, |allowed| will remain false.
 
         1. Return "<code>[=storage access status/none=]</code>".
 </div>


### PR DESCRIPTION
This doesn't change behavior, but it flattens the algorithm's steps and makes the semantics re: permissions policy more explicit. (It also avoids invoking `Should request be allowed to use feature?` unless really necessary.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access-headers/pull/24.html" title="Last updated on Jan 9, 2025, 4:28 PM UTC (56353d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access-headers/24/d317d4c...56353d0.html" title="Last updated on Jan 9, 2025, 4:28 PM UTC (56353d0)">Diff</a>