### PR TITLE
Update RFC 8941 to 9651

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -20,7 +20,7 @@ Include Can I Use Panels: yes
 {
   "I-D.structured-field-values-for-http": {
     "authors": [ "Mark Nottingham", "Poul-Henning Kamp" ],
-    "href": "https://datatracker.ietf.org/doc/html/rfc8941",
+    "href": "https://datatracker.ietf.org/doc/html/rfc9651",
     "title": "Structured Field Values for HTTP",
     "status": "ID",
     "publisher": "IETF"
@@ -39,7 +39,7 @@ spec: storage-access; type: method; text: requestStorageAccess
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941; spec: I-D.structured-field-values-for-http
+urlPrefix: https://datatracker.ietf.org/doc/html/rfc9651; spec: I-D.structured-field-values-for-http
     type: dfn
         text: structured field; url: #
     for: structured field


### PR DESCRIPTION
RFC 9651 obsoletes 8941


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sandormajor/storage-access-headers/pull/27.html" title="Last updated on Jan 29, 2025, 4:14 PM UTC (5b251eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access-headers/27/fb1438e...sandormajor:5b251eb.html" title="Last updated on Jan 29, 2025, 4:14 PM UTC (5b251eb)">Diff</a>