### PR TITLE
Update SAH spec atop SAA request changes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -59,6 +59,15 @@ spec: storage-access; urlPrefix: https://privacycg.github.io/storage-access/
             text: environment id; url: source-snapsnot-params-environment-id
     type: dfn
         text: determine whether the user agent explicitly allows unpartitioned cookie access; url: #determine-whether-the-user-agent-explicitly-allows-unpartitioned-cookie-access
+        text: storage access eligibility; url: #storage-access-eligibility
+    for: storage access eligibility
+        type: dfn
+            text: unset; url: #storage-access-eligibility-unset
+            text: ineligible; url: #storage-access-eligibility-ineligible
+            text: eligible; url: #storage-access-eligibility-eligible
+    for: request
+        type: dfn
+            text: eligible for storage-access; url: #request-eligible-for-storage-access
 urlPrefix: https://fetch.spec.whatwg.org/
     type: dfn
         text: append a request Origin header; url: #append-a-request-origin-header
@@ -99,12 +108,6 @@ Storage-Access Request Infrastructure {#request-infrastructure}
 
 In addition to the new headers themselves, this document introduces some new infrastructure to store and convey metadata in the [=user agent=], particularly on a [=request=].
 
-A [=request=] has a boolean <dfn for="request">eligible for storage-access</dfn>. It is initially false.
-
-    Note: The [=request/eligible for storage-access=] boolean indicates whether the user agent is allowed to include unpartitioned cookies when sending a [=request=] where the site [=obtain a site|obtained=] from the request's [=request/url=] has a storage-access permission.
-
-    Note: A [=request=] also has a [=environment/has storage access=] boolean, indirectly through its [=request/client=]. That value is distinct from the [=request=]'s [=request/eligible for storage-access=] boolean. Both represent an "opt in" signal for accessing unpartitioned cookies in a cross-site context, but the signal comes from different [=origin=]s. The [=request=]'s [=request/client=]'s [=environment/has storage access=] field represents whether the [=site=] [=obtain a site|obtained=] from the [=environment=]'s [=environment settings object/origin=] has opted in. The [=request=]'s [=request/eligible for storage-access=] field represents whether the [=site=] [=obtain a site|obtained=] from the [=request=]'s [=request/url=]'s [=url/origin=] has opted in.
-
 A [=request=] has an associated <dfn for="request">single-hop cache mode</dfn>, whose value is null or a [=request/cache mode=]. It is initially set to null.
 
 This document renames a [=request=]'s [=request/cache mode=] field to <dfn for="request">internal cache mode</dfn>.
@@ -122,7 +125,7 @@ A <dfn>storage access status</dfn> is one of "<dfn for="storage access status">n
         1. If the user agent's cookie store would attach cookies with the `SameSite=Strict` attribute to |request|, return null. [[!COOKIES]]
         1. Let |allowed| be a [=boolean=], initially set to the result of [=determining whether the user agent's cookie store allows unpartitioned cookies to be accessed=] given |request|'s [=request/url=], |request|'s [=request/client=], and |request|'s [=request/eligible for storage-access=].
         1. If |allowed| is true, return "<code>[=storage access status/active=]</code>".
-        1. If |request|'s [=request/eligible for storage-access=] is true, return "<code>[=storage access status/none=]</code>".
+        1. If |request|'s [=request/eligible for storage-access=] is "<code>[=storage access eligibility/eligible=]</code>", return "<code>[=storage access status/none=]</code>".
 
             Note: the "`storage-access`" [=policy-controlled feature=] was checked before setting |request|'s [=request/eligible for storage-access=] to true.
 
@@ -137,14 +140,14 @@ A <dfn>storage access status</dfn> is one of "<dfn for="storage access status">n
 </div>
 
 <div algorithm>
-    To <dfn>determine whether the user agent's cookie store allows unpartitioned cookies to be accessed</dfn>, given a [=url=] |url|, an [=environment settings object=] |environment|, and a boolean |eligible for storage-access|, run the following steps (which return a boolean):
+    To <dfn>determine whether the user agent's cookie store allows unpartitioned cookies to be accessed</dfn>, given a [=url=] |url|, an [=environment settings object=] |environment|, and a [=storage access eligibility=] |storage access eligibility|, run the following steps (which return a boolean):
         1. Let |top level site| be the result of [=obtaining a site=] from |environment|'s [=environment/top-level origin=].
         1. Let |destination site| be the the result of [=obtaining a site=] from |url|'s [=url/origin=].
         1. Let |key| be <code>(|top level site|, |destination site|)</code>.
         1. Let |allowed| be the result of [=determining whether the user agent explicitly allows unpartitioned cookie access=] given |key|.
         1. If |allowed| is true, return true.
         1. Return false if all of the following conditions are false:
-            * |eligible for storage-access| is true
+            * |storage access eligibility| is "<code>[=storage access eligibility/eligible=]</code>"
             * |environment|'s [=environment/has storage access=] is true and the site [=obtain a site|obtained=] from |environment|'s [=environment settings object/origin=] and the site [=obtain a site|obtained=] from |url|'s [=url/origin=] are [=same site=]
 
                 Issue: This condition ought to check a boolean that is updated after cross-site HTTP redirects. I.e., it ought to read a boolean derived from the |environment|'s [=environment/has storage access=], not that value itself. See [storage-access#210](https://github.com/privacycg/storage-access/issues/210).
@@ -240,7 +243,7 @@ Activate-Storage-Access: retry; allowed-origin=*
 
     <ol class="algorithm">
         1. If |request|'s [=request/credentials mode=] is not "`include`", return failure.
-        1. If |request|'s [=request/eligible for storage-access=] is true, return failure.
+        1. If |request|'s [=request/eligible for storage-access=] is "<code>[=storage access eligibility/eligible=]</code>", return failure.
         1. Let |storageAccessStatus| be |request|'s [=request/storage access status=].
         1. If |storageAccessStatus| is not "<code>[=storage access status/inactive=]</code>", return failure.
         1. Let |parsedHeader| be the result of [=header list/get a structured field value|getting a structured field value=] given "`Activate-Storage-Access`" and "`item`" from |response|'s [=response/header list=].
@@ -322,12 +325,12 @@ The rest of the algorithm is unmodified.
 
     1. Let |request| be |fetchParams|'s [=request=].
     1. Assert: |request|'s [=request/storage access status=] is "<code>[=storage access status/inactive=]</code>".
-    1. Assert: |request|'s [=request/eligible for storage-access=] is false.
+    1. Assert: |request|'s [=request/eligible for storage-access=] is not "<code>[=storage access eligibility/eligible=]</code>".
     1. If |request|'s [=request/redirect count=] is 20, then return a [=network error=].
     1. Increase |request|'s [=request/redirect count=] by 1.
     1. [=list/Append=] |request|'s [=request/url=] to |request|'s [=request/URL list=].
     1. Set |request|'s [=request/single-hop cache mode=] to "`reload`".
-    1. Set |request|'s [=request/eligible for storage-access=] to true.
+    1. Set |request|'s [=request/eligible for storage-access=] to "<code>[=storage access eligibility/eligible=]</code>".
     1. Assert: |request|'s [=request/storage access status=] is "<code>[=storage access status/active=]</code>".
     1. Let |recursive| be true.
     1. Return the result of running [=main fetch=] given |fetchParams| and |recursive|.
@@ -338,7 +341,7 @@ The rest of the algorithm is unmodified.
 Insert a new step after step 17 in [=HTTP-redirect fetch=]:
 
 <div algorithm="modified HTTP-redirect fetch">
-    18. If <var ignore>locationURL</var>'s [=url/origin=] is not [=same origin=] with |request|'s [=request/url=]'s [=url/origin=], set |request|'s [=request/eligible for storage-access=] to false.
+    18. If |request|'s [=request/eligible for storage-access=] is "<code>[=storage access eligibility/eligible=]</code>" and <var ignore>locationURL</var>'s [=url/origin=] is not [=same origin=] with |request|'s [=request/url=]'s [=url/origin=], set |request|'s [=request/eligible for storage-access=] to "<code>[=storage access eligibility/ineligible=]</code>".
 </div>
 
 


### PR DESCRIPTION
Updates to use the `request` infrastructure now defined in Storage Access, in https://github.com/privacycg/storage-access/pull/214.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access-headers/pull/33.html" title="Last updated on Apr 18, 2025, 7:05 PM UTC (5a0e05d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access-headers/33/6eb693d...5a0e05d.html" title="Last updated on Apr 18, 2025, 7:05 PM UTC (5a0e05d)">Diff</a>