### PR TITLE
Adjust metadata following move to Privacy CG

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,11 +2,13 @@
 Title: Storage Access Headers
 Shortname: storage-access-headers
 Level: None
-Status: w3c/UD
-Repository: cfredric/storage-access-headers
-URL: https://cfredric.github.io/storage-access-headers
+Group: privacycg
+Status: CG-DRAFT
+Repository: privacycg/storage-access-headers
+URL: https://privacycg.github.io/storage-access-headers
 Editor: Chris Fredrickson, Google https://google.com, cfredric@google.com
 Abstract: This document defines a pair of request and response headers that aim to give servers information about whether unpartitioned cookies were (or could be) included on a request, and provide the ability for servers to allow those cookies to be sent (if the user has already relaxed the privacy boundary via the Storage Access API).
+Text Macro: LICENSE <a href=https://creativecommons.org/licenses/by/4.0/>Creative Commons Attribution 4.0 International License</a>
 Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 yes, missing-example-ids yes
 Assume Explicit For: yes

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,5 @@
+{
+  "group": "cg/privacycg",
+  "contacts": ["hober", "martinthomson", "erik-anderson"],
+  "repo-type": "cg-report"
+}


### PR DESCRIPTION
This moves the spec from an "Unofficial Proposal Draft" to a "CG Draft" following the group's adoption of the spec, adjusts a couple of URLs, and creates the missing `w3c.json` file.

The boilerplate text in Bikeshed seems to require a LICENSE macro text. This sets it to the value found in other Privacy CG proposals.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/storage-access-headers/pull/37.html" title="Last updated on Oct 27, 2025, 8:47 AM UTC (92c04ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access-headers/37/d73c092...tidoust:92c04ee.html" title="Last updated on Oct 27, 2025, 8:47 AM UTC (92c04ee)">Diff</a>